### PR TITLE
Added CUDA to LD_LIBRARY_PATH

### DIFF
--- a/installation/chroma3.435/chroma_env.sh
+++ b/installation/chroma3.435/chroma_env.sh
@@ -4,6 +4,7 @@ if [ -e /opt/anaconda3/bin/conda ]; then
     export CPATH="/opt/anaconda3/include:$CPATH"
     export LIBRARY_PATH="$LIBRARY_PATH:/opt/anaconda3/lib"
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/anaconda3/lib"
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/cuda/lib64"
 fi
 if [ -e /opt/root/bin/thisroot.sh ]; then
     source /opt/root/bin/thisroot.sh

--- a/installation/chroma3.440/chroma_env.sh
+++ b/installation/chroma3.440/chroma_env.sh
@@ -4,6 +4,7 @@ if [ -e /opt/anaconda3/bin/conda ]; then
     export CPATH="/opt/anaconda3/include:$CPATH"
     export LIBRARY_PATH="$LIBRARY_PATH:/opt/anaconda3/lib"
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/anaconda3/lib"
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/cuda/lib64"
 fi
 if [ -e /opt/root/bin/thisroot.sh ]; then
     source /opt/root/bin/thisroot.sh

--- a/installation/chroma3.latest/chroma_env.sh
+++ b/installation/chroma3.latest/chroma_env.sh
@@ -4,6 +4,7 @@ if [ -e /opt/anaconda3/bin/conda ]; then
     export CPATH="/opt/anaconda3/include:$CPATH"
     export LIBRARY_PATH="$LIBRARY_PATH:/opt/anaconda3/lib"
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/anaconda3/lib"
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/cuda/lib64"
 fi
 if [ -e /opt/root/bin/thisroot.sh ]; then
     source /opt/root/bin/thisroot.sh


### PR DESCRIPTION
I needed to include CUDA into the `LD_LIBRARY_PATH` to get pyCude to play nice. Otherwise programs using pycuda would fail at `cuda.init()`.