### PR TITLE
Fix missing qedep variable for particle tracking

### DIFF
--- a/chroma/io/root.py
+++ b/chroma/io/root.py
@@ -86,7 +86,7 @@ def python_vertex_to_root_vertex(pvertex,rvertex):
     if pvertex.steps:
         ROOT.fill_steps(rvertex,len(pvertex.steps.x),pvertex.steps.x,pvertex.steps.y,pvertex.steps.z,
                         pvertex.steps.t,pvertex.steps.dx,pvertex.steps.dy,pvertex.steps.dz,
-                        pvertex.steps.ke,pvertex.steps.edep)
+                        pvertex.steps.ke,pvertex.steps.edep,pvertex.steps.qedep)
     else:
         nil = np.empty(0,dtype=np.float64)
         ROOT.clear_steps(rvertex)


### PR DESCRIPTION
`fill_steps()` was missing the new `qedep` parameter, which caused errors when particle tracking was enabled.