### PR TITLE
Multiple event viewer

### DIFF
--- a/chroma/camera.py
+++ b/chroma/camera.py
@@ -876,7 +876,7 @@ class EventViewer(Camera):
                 self.gpu_geometries.append(gpu_geometry)
     
     def render_mc_info_all_events(self):
-        #function added by Sam to visualize all events in a root file at the same time
+        #function added to visualize all events in a root file at the same time
         self.gpu_geometries = [self.gpu_geometry]
         for i, ev in enumerate(self.rr):
             print('Evaluating event %i' %i)
@@ -911,7 +911,7 @@ class EventViewer(Camera):
                     scintillation = scintillation[selector]
                     reemission = reemission[selector]
                 nphotons = len(tracks)
-                prob = self.photons_max/nphotons if self.photons_max is not None and nphotons is not 0 else 1.0 #Sam added and nphotons is not 0
+                prob = self.photons_max/nphotons if self.photons_max is not None and nphotons is not 0 else 1.0
                 selector = np.random.random(len(tracks)) < prob
                 nphotons = np.count_nonzero(selector)
                 for i,track in ((i,t) for i,(s,t) in enumerate(zip(selector,tracks)) if s):

--- a/chroma/camera.py
+++ b/chroma/camera.py
@@ -855,7 +855,7 @@ class EventViewer(Camera):
                 scintillation = scintillation[selector]
                 reemission = reemission[selector]
             nphotons = len(tracks)
-            prob = self.photons_max/nphotons if self.photons_max is not None else 1.0
+            prob = self.photons_max/nphotons if self.photons_max is not None and nphotons is not 0 else 1.0 #Sam added and nphotons is not 0
             selector = np.random.random(len(tracks)) < prob
             nphotons = np.count_nonzero(selector)
             for i,track in ((i,t) for i,(s,t) in enumerate(zip(selector,tracks)) if s):

--- a/chroma/camera.py
+++ b/chroma/camera.py
@@ -978,7 +978,7 @@ class EventViewer(Camera):
                 else:
                     self.color_hit_pmts()
                     self.render_mc_info()
-                    #self.update() #FIXME
+                    self.update()
                 return
 
             elif event.key == K_LEFT and not self.sum_mode:

--- a/chroma/camera.py
+++ b/chroma/camera.py
@@ -1062,7 +1062,6 @@ class EventViewer(Camera):
                 self.render_mc_info()
                 self.update()
                 return
-            #added by Sam to enable looking at multiple events
             elif event.key == K_o:
                 self.render_mc_info_all_events()
                 self.update()

--- a/chroma/camera.py
+++ b/chroma/camera.py
@@ -855,7 +855,7 @@ class EventViewer(Camera):
                 scintillation = scintillation[selector]
                 reemission = reemission[selector]
             nphotons = len(tracks)
-            prob = self.photons_max/nphotons if self.photons_max is not None and nphotons is not 0 else 1.0 #Sam added and nphotons is not 0
+            prob = self.photons_max/nphotons if self.photons_max is not None and nphotons is not 0 else 1.0
             selector = np.random.random(len(tracks)) < prob
             nphotons = np.count_nonzero(selector)
             for i,track in ((i,t) for i,(s,t) in enumerate(zip(selector,tracks)) if s):

--- a/chroma/camera.py
+++ b/chroma/camera.py
@@ -877,20 +877,20 @@ class EventViewer(Camera):
     
     def render_mc_info_all_events(self):
         #function added by Sam to visualize all events in a root file at the same time
+        self.gpu_geometries = [self.gpu_geometry]
         for i, ev in enumerate(self.rr):
             print('Evaluating event %i' %i)
-            self.gpu_geometries = [self.gpu_geometry]
-            if self.sum_mode or self.ev is None:
+            if self.sum_mode or ev is None:
                 return
  
-            if self.track_display_mode in ['chroma', 'both'] and self.ev.photon_tracks is not None:
+            if self.track_display_mode in ['chroma', 'both'] and ev.photon_tracks is not None:
                 geometry = Geometry()
-                print('Total Photons',len(self.ev.photon_tracks))
+                print('Total Photons',len(ev.photon_tracks))
                 
                 def has(flags,test):
                     return flags & test == test
                 
-                tracks = self.ev.photon_tracks
+                tracks = ev.photon_tracks
                 if self.photons_detected_only:
                     detected = np.asarray([has(track.flags[-1],event.SURFACE_DETECT) for track in tracks])
                     tracks = [t for t,m in zip(tracks,detected) if m]

--- a/chroma/camera.py
+++ b/chroma/camera.py
@@ -978,7 +978,7 @@ class EventViewer(Camera):
                 else:
                     self.color_hit_pmts()
                     self.render_mc_info()
-                    self.update()
+                    #self.update() #FIXME
                 return
 
             elif event.key == K_LEFT and not self.sum_mode:

--- a/chroma/camera.py
+++ b/chroma/camera.py
@@ -874,7 +874,63 @@ class EventViewer(Camera):
                 geometry = create_geometry_from_obj(geometry)
                 gpu_geometry = gpu.GPUGeometry(geometry)
                 self.gpu_geometries.append(gpu_geometry)
-            
+    
+    def render_mc_info_all_events(self):
+        #function added by Sam to visualize all events in a root file at the same time
+        for i, ev in enumerate(self.rr):
+            print('Evaluating event %i' %i)
+            self.gpu_geometries = [self.gpu_geometry]
+            if self.sum_mode or self.ev is None:
+                return
+ 
+            if self.track_display_mode in ['chroma', 'both'] and self.ev.photon_tracks is not None:
+                geometry = Geometry()
+                print('Total Photons',len(self.ev.photon_tracks))
+                
+                def has(flags,test):
+                    return flags & test == test
+                
+                tracks = self.ev.photon_tracks
+                if self.photons_detected_only:
+                    detected = np.asarray([has(track.flags[-1],event.SURFACE_DETECT) for track in tracks])
+                    tracks = [t for t,m in zip(tracks,detected) if m]
+                cherenkov = np.asarray([has(track.flags[0],event.CHERENKOV) and not has(track.flags[-1],event.BULK_REEMIT) for track in tracks])
+                scintillation = np.asarray([has(track.flags[0],event.SCINTILLATION) and not has(track.flags[-1],event.BULK_REEMIT) for track in tracks])
+                reemission = np.asarray([has(track.flags[-1],event.BULK_REEMIT) for track in tracks])
+                if self.photons_only_type is not None:
+                    if self.photons_only_type == 'cher':
+                        selector = cherenkov
+                    elif self.photons_only_type == 'scint':
+                        selector = scintillation
+                    elif self.photons_only_type == 'reemit':
+                        selector = reemission
+                    else:
+                        raise Exception('Unknown only type: %s'%only)
+                    tracks = [t for t,m in zip(tracks,selector) if m]
+                    cherenkov = cherenkov[selector]
+                    scintillation = scintillation[selector]
+                    reemission = reemission[selector]
+                nphotons = len(tracks)
+                prob = self.photons_max/nphotons if self.photons_max is not None and nphotons is not 0 else 1.0 #Sam added and nphotons is not 0
+                selector = np.random.random(len(tracks)) < prob
+                nphotons = np.count_nonzero(selector)
+                for i,track in ((i,t) for i,(s,t) in enumerate(zip(selector,tracks)) if s):
+                    if cherenkov[i]:
+                        color = [255,0,0]
+                    elif scintillation[i]:
+                        color = [0,0,255]
+                    elif reemission[i]:
+                        color = [0,255,0]
+                    else:
+                        color = [255,255,255]
+                    steps = min(len(track),self.photons_max_steps) if self.photons_max_steps is not None else len(track)
+                    self.render_photon_track(geometry,track[:steps],sz=self.photons_track_size,color=color)
+                if nphotons > 0:
+                    print('Rendered Photons',nphotons)
+                    geometry = create_geometry_from_obj(geometry)
+                    gpu_geometry = gpu.GPUGeometry(geometry)
+                    self.gpu_geometries.append(gpu_geometry)
+                
 
     def sum_events(self):
         print('Summing events in file...')
@@ -1004,6 +1060,11 @@ class EventViewer(Camera):
                     return
                 self.color_hit_pmts()
                 self.render_mc_info()
+                self.update()
+                return
+            #added by Sam to enable looking at multiple events
+            elif event.key == K_o:
+                self.render_mc_info_all_events()
                 self.update()
                 return
 

--- a/chroma/sim.py
+++ b/chroma/sim.py
@@ -141,6 +141,7 @@ class Simulation(object):
     def simulate(self, iterable, keep_photons_beg=False, keep_photons_end=False,
                  keep_hits=True, keep_flat_hits=True, run_daq=False, max_steps=1000,
                  photons_per_batch=1000000):
+        print('Running sim...')
         if isinstance(iterable, event.Photons):
             first_element, iterable = iterable, [iterable]
         else:

--- a/chroma/sim.py
+++ b/chroma/sim.py
@@ -141,7 +141,6 @@ class Simulation(object):
     def simulate(self, iterable, keep_photons_beg=False, keep_photons_end=False,
                  keep_hits=True, keep_flat_hits=True, run_daq=False, max_steps=1000,
                  photons_per_batch=1000000):
-        print('Running sim...')
         if isinstance(iterable, event.Photons):
             first_element, iterable = iterable, [iterable]
         else:


### PR DESCRIPTION
Allows visualization of photon tracks from multiple events simultaneously. Also adds a fix that prevents the event viewer from crashing when an event with no photons is rendered.